### PR TITLE
Provide commands detailed info in main README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,18 @@ Every time `composer update` is run, Composer Test Scenarios will run the `compo
 
 As an added service, the Copyright notice in your LICENSE file is also updated to include the current year, if it is not already mentioned in the Copyright notice.
 
+## Commands
+
+Scenarios will be updated every time `composer update` is executed. However, you can manually invoke the various commands provided by this plugin, while avoiding running `composer update` on your project, which may be not desirable.
+
+`composer scenario:update`: Updates all scenarios defined in your composer.json file to the latest versions. If a specific scenario does not exist, it creates the lock folder.
+
+`composer scenario <name>` : Installs a scenario.
+
+`composer update:lock`: Upgrades your dependencies to the latest version according to composer.json without downloading any of them; only updates the composer.lock file.
+
+`composer dependency-licenses`: Adds information about the licenses used by project's dependencies to its LICENSE file.
+
 ## Upgrading
 
 If your project is already using an older version of Composer Test Scenarios, see [UPGRADING.md](UPGRADING.md).


### PR DESCRIPTION
In some cases may not be desirable to call `composer update` on a project, considering the implications on the composer.lock file. This is especially true if you are doing this because of a (great) plugin that you use for testing purposes.

This plugin can still be useful, though, as individual commands can be executed per-se.

Adding this part of explanation that I am proposing to the main readme would help people landing on the GitHub repo to understand that running `composer update` is not required. Otherwise, in order to know it, you should run `composer list` or go through the code.