### PR TITLE
Scenarios are incompatible with composer-patches plugin

### DIFF
--- a/scripts/install-scenario
+++ b/scripts/install-scenario
@@ -48,7 +48,7 @@ echo
 set -ex
 
 composer -n validate --working-dir=$dir --no-check-all --ansi
-composer -n --working-dir=$dir ${DEPENDENCIES} --prefer-dist --no-scripts
+composer -n --working-dir=$dir ${DEPENDENCIES} --prefer-dist
 
 # If called from a CI context, print out some extra information about
 # what we just installed.

--- a/scripts/install-scenario
+++ b/scripts/install-scenario
@@ -4,16 +4,16 @@ SCENARIO=$1
 DEPENDENCIES=${2-install}
 
 # Convert the aliases 'highest', 'lowest' and 'lock' to
-# the corresponding composer command to run.
+# the corresponding composer update command to run.
 case $DEPENDENCIES in
   highest)
-    DEPENDENCIES=update
+    UPDATE_COMMAND=update
     ;;
   lowest)
-    DEPENDENCIES='update --prefer-lowest'
+    UPDATE_COMMAND='update --prefer-lowest'
     ;;
   lock|default|"")
-    DEPENDENCIES=install
+    UPDATE_COMMAND=''
     ;;
 esac
 
@@ -48,7 +48,11 @@ echo
 set -ex
 
 composer -n validate --working-dir=$dir --no-check-all --ansi
-composer -n --working-dir=$dir ${DEPENDENCIES} --prefer-dist
+
+if [ ! -z "$UPDATE_COMMAND" ] ; then
+  composer -n --working-dir=$dir ${UPDATE_COMMAND} --prefer-dist --no-scripts
+fi
+composer -n --working-dir=$dir install --prefer-dist
 
 # If called from a CI context, print out some extra information about
 # what we just installed.

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -404,8 +404,7 @@ class Handler
             foreach ($patches as $info => $path) {
                 if (filter_var($path, FILTER_VALIDATE_URL)) {
                     $result[$package][$info] = $path;
-                }
-                else {
+                } else {
                     $result[$package][$info] = "../../$path";
                 }
             }

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -176,7 +176,12 @@ class Handler
         if ($status != 0) {
             return $status;
         }
-        passthru("composer -n --working-dir=$scenarioDir $scenarioCommand $extraOptions --prefer-dist", $status);
+
+        if ($scenarioCommand == 'update') {
+            passthru("composer -n --working-dir=$scenarioDir update $extraOptions --prefer-dist --no-scripts", $status);
+        }
+
+        passthru("composer -n --working-dir=$scenarioDir install $extraOptions --prefer-dist", $status);
         return $status;
     }
 
@@ -385,10 +390,10 @@ class Handler
 
     /**
      *   "patches": {
-     *       "drupal/field_collection": {
-     *           "HTTP patch": "https://www.drupal.org/files/issues/field_collection-null-values-on-editing-2662210-2-7.x-1.x.patch",
-     *           "Local patch": "patches/field_collectiion.patch"
-     *       }
+     *       "drupal/drupal": {
+     *          "Drupal.org patch": "https://www.drupal.org/files/issues/random-patch-999999-2.patch",
+     *          "Local patch": "patches/local.patch"
+     *      }
      *   }
      */
     protected function fixPatchesPaths($patchesPathData)
@@ -396,12 +401,12 @@ class Handler
         $result = [];
 
         foreach ($patchesPathData as $package => $patches) {
-            foreach ($patches as $info => $patch) {
-                if (filter_var($patch, FILTER_VALIDATE_URL)) {
-                    $result['package'][$info] = $path;
+            foreach ($patches as $info => $path) {
+                if (filter_var($path, FILTER_VALIDATE_URL)) {
+                    $result[$package][$info] = $path;
                 }
                 else {
-                    $result['package'][$info] = "../../$path";
+                    $result[$package][$info] = "../../$path";
                 }
             }
         }

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -176,7 +176,7 @@ class Handler
         if ($status != 0) {
             return $status;
         }
-        passthru("composer -n --working-dir=$scenarioDir $scenarioCommand $extraOptions --prefer-dist --no-scripts", $status);
+        passthru("composer -n --working-dir=$scenarioDir $scenarioCommand $extraOptions --prefer-dist", $status);
         return $status;
     }
 
@@ -335,6 +335,10 @@ class Handler
             $composerData['extra']['installer-paths'] = $this->fixInstallerPaths($composerData['extra']['installer-paths']);
         }
 
+        if (isset($composerData['extra']['patches'])) {
+            $composerData['extra']['patches'] = $this->fixPatchesPaths($composerData['extra']['patches']);
+        }
+
         return $composerData;
     }
 
@@ -374,6 +378,32 @@ class Handler
 
         foreach ($installerPathData as $path => $types) {
             $result["../../$path"] = $types;
+        }
+
+        return $result;
+    }
+
+    /**
+     *   "patches": {
+     *       "drupal/field_collection": {
+     *           "HTTP patch": "https://www.drupal.org/files/issues/field_collection-null-values-on-editing-2662210-2-7.x-1.x.patch",
+     *           "Local patch": "patches/field_collectiion.patch"
+     *       }
+     *   }
+     */
+    protected function fixPatchesPaths($patchesPathData)
+    {
+        $result = [];
+
+        foreach ($patchesPathData as $package => $patches) {
+            foreach ($patches as $info => $patch) {
+                if (filter_var($patch, FILTER_VALIDATE_URL)) {
+                    $result['package'][$info] = $path;
+                }
+                else {
+                    $result['package'][$info] = "../../$path";
+                }
+            }
         }
 
         return $result;

--- a/tests/PatchesTest.php
+++ b/tests/PatchesTest.php
@@ -1,0 +1,47 @@
+<?php
+namespace ComposerTestScenarios;
+
+use PHPUnit\Framework\TestCase;
+
+class PatchesTest extends TestCase
+{
+    use Fixtures;
+    use RunComposer;
+
+    /**
+     * testExampleA starts with an example project that contains a default
+     * scenario and one other scenario, and ensures that the alternate scenario
+     * can be created and installed.
+     */
+    public function testPatches()
+    {
+        // Create the project directory to work with
+        $testProjectDir = $this->createTestProject('with-patches');
+
+        // Run 'composer update' to build the scenario directories
+        list($output, $status) = $this->composer('update', $testProjectDir);
+        $this->assertNotContains('Your requirements could not be resolved to an installable set of packages.', $output);
+        $this->assertEquals(0, $status);
+
+        // Check the scenario directory
+
+        $scenarioDir = \ComposerTestScenarios\Handler::scenarioLockDir($testProjectDir, 'semver10');
+        $this->assertTrue(is_dir($scenarioDir));
+
+        // The scenario directory should be different than the base directory
+        $this->assertNotEquals($testProjectDir, $scenarioDir);
+
+        // There shouldn't be any composer.lock
+        $this->assertTrue(!file_exists($scenarioDir . '/composer.lock'));
+
+        // Read the generated composer.json file
+
+        $generatedComposerFile = file_get_contents($scenarioDir . '/composer.json');
+
+        $expected = '../../patches/local.patch';
+        $this->assertContains($expected, $generatedComposerFile);
+
+        $incorrectUrl = '../../https://www.drupal.org/files/issues/random-patch-999999-2.patch';
+        $this->assertNotContains($incorrectUrl, $generatedComposerFile);
+    }
+}

--- a/tests/PatchesTest.php
+++ b/tests/PatchesTest.php
@@ -41,7 +41,7 @@ class PatchesTest extends TestCase
         $expected = '../../patches/local.patch';
         $this->assertContains($expected, $generatedComposerFile);
 
-        $incorrectUrl = '../../https://www.drupal.org/files/issues/random-patch-999999-2.patch';
+        $incorrectUrl = '../../file://test/directory/url.patch';
         $this->assertNotContains($incorrectUrl, $generatedComposerFile);
     }
 }

--- a/tests/fixtures/projects/simple-project/composer.json
+++ b/tests/fixtures/projects/simple-project/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "composer/semver": "^1.4"
+        "composer/semver": "~1.4.0"
     },
     "require-dev": {
         "g1a/composer-test-scenarios": "dev-__BRANCH__"

--- a/tests/fixtures/projects/with-patches/composer.json
+++ b/tests/fixtures/projects/with-patches/composer.json
@@ -33,7 +33,7 @@
         "patches": {
             "composer/semver" : {
                 "Local patch" : "patches/local.patch",
-                "Drupal.org patch": "https://www.drupal.org/files/issues/random-patch-999999-2.patch"
+                "URL patch": "file://test/directory/url.patch"
             }
         }
     }

--- a/tests/fixtures/projects/with-patches/composer.json
+++ b/tests/fixtures/projects/with-patches/composer.json
@@ -1,0 +1,40 @@
+{
+    "name": "g1a/simple-project",
+    "description": "A test project for composer-test-scenarios.",
+    "license": "MIT",
+    "repositories": [
+        {
+            "type": "path",
+            "url": "__SUT__"
+        }
+    ],
+    "require": {
+        "composer/semver": "^1.4"
+    },
+    "require-dev": {
+        "g1a/composer-test-scenarios": "dev-__BRANCH__"
+    },
+    "autoload": {
+        "psr-4": {
+            "ComposerTestScenarios\\": "src/"
+        }
+    },
+    "extra": {
+        "scenarios": {
+            "semver10": {
+                "require": {
+                    "composer/semver": "~1.0.0"
+                },
+                "scenario-options": {
+                    "create-lockfile": "false"
+                }
+            }
+        },
+        "patches": {
+            "composer/semver" : {
+                "Local patch" : "patches/local.patch",
+                "Drupal.org patch": "https://www.drupal.org/files/issues/random-patch-999999-2.patch"
+            }
+        }
+    }
+}


### PR DESCRIPTION
When creating SUT's that involve Drupal 8, cweagans's composer-patches plugin (a popular plugin for applying patches on Drupal composer projects) requires a) the ability to run-scripts a nd b) a directory adjustment similar to the one that occurs with "extra:installer-paths".