### PR TITLE
Scenarios are incompatible with preserve-paths plugin

### DIFF
--- a/src/Handler.php
+++ b/src/Handler.php
@@ -336,6 +336,10 @@ class Handler
             $composerData['autoload-dev'] = $this->fixAutoloadPaths($composerData['autoload-dev']);
         }
 
+        if (isset($composerData['extra']['preserve-paths'])) {
+            $composerData['extra']['preserve-paths'] = $this->fixPreservePaths($composerData['extra']['preserve-paths']);
+        }
+
         if (isset($composerData['extra']['installer-paths'])) {
             $composerData['extra']['installer-paths'] = $this->fixInstallerPaths($composerData['extra']['installer-paths']);
         }
@@ -368,6 +372,25 @@ class Handler
         }
 
         return $autoloadData;
+    }
+
+    /**
+     *     "preserve-paths": [
+     *       "web/sites/all/libraries",
+     *       "web/sites/all/modules/contrib",
+     *       "web/sites/all/themes/contrib",
+     *       "web/sites/default"
+     *   ],
+     */
+    protected function fixPreservePaths($preservePathsData)
+    {
+        $result = [];
+
+        foreach ($preservePathsData as $path) {
+            $result[] = "../../$path";
+        }
+
+        return $result;
     }
 
     /**

--- a/tests/PreservePathsTest.php
+++ b/tests/PreservePathsTest.php
@@ -1,0 +1,44 @@
+<?php
+namespace ComposerTestScenarios;
+
+use PHPUnit\Framework\TestCase;
+
+class PreservePathsTest extends TestCase
+{
+    use Fixtures;
+    use RunComposer;
+
+    /**
+     * testExampleA starts with an example project that contains a default
+     * scenario and one other scenario, and ensures that the alternate scenario
+     * can be created and installed.
+     */
+    public function testPreservePaths()
+    {
+        // Create the project directory to work with
+        $testProjectDir = $this->createTestProject('with-preserve-paths');
+
+        // Run 'composer update' to build the scenario directories
+        list($output, $status) = $this->composer('update', $testProjectDir);
+        $this->assertNotContains('Your requirements could not be resolved to an installable set of packages.', $output);
+        $this->assertEquals(0, $status);
+
+        // Check the scenario directory
+
+        $scenarioDir = \ComposerTestScenarios\Handler::scenarioLockDir($testProjectDir, 'semver10');
+        $this->assertTrue(is_dir($scenarioDir));
+
+        // The scenario directory should be different than the base directory
+        $this->assertNotEquals($testProjectDir, $scenarioDir);
+
+        // There shouldn't be any composer.lock
+        $this->assertTrue(!file_exists($scenarioDir . '/composer.lock'));
+
+        // Read the generated composer.json file
+
+        $generatedComposerFile = file_get_contents($scenarioDir . '/composer.json');
+
+        $expected = '../../web/sites/all/modules/contrib';
+        $this->assertContains($expected, $generatedComposerFile);
+    }
+}

--- a/tests/fixtures/projects/with-preserve-paths/composer.json
+++ b/tests/fixtures/projects/with-preserve-paths/composer.json
@@ -1,0 +1,40 @@
+{
+    "name": "g1a/simple-project",
+    "description": "A test project for composer-test-scenarios.",
+    "license": "MIT",
+    "repositories": [
+        {
+            "type": "path",
+            "url": "__SUT__"
+        }
+    ],
+    "require": {
+        "composer/semver": "^1.4"
+    },
+    "require-dev": {
+        "g1a/composer-test-scenarios": "dev-__BRANCH__"
+    },
+    "autoload": {
+        "psr-4": {
+            "ComposerTestScenarios\\": "src/"
+        }
+    },
+    "extra": {
+        "scenarios": {
+            "semver10": {
+                "require": {
+                    "composer/semver": "~1.0.0"
+                },
+                "scenario-options": {
+                    "create-lockfile": "false"
+                }
+            }
+        },
+        "preserve-paths": [
+           "web/sites/all/libraries",
+           "web/sites/all/modules/contrib",
+           "web/sites/all/themes/contrib",
+           "web/sites/default"
+       ]
+    }
+}


### PR DESCRIPTION
Similar to issue #9, composer-test-scenarios does not adjust paths for preserve-paths attributes on its scenarios.

Example composer.json that reproduces the issue:

```
{
  "name": "frodri/drush-extension-pack",
  "description": "A collection of custom Drush extensions",
  "repositories": [
    {
      "type": "composer",
      "url": "https://packages.drupal.org/7"
    }
  ],
  "require": {
    "composer/installers": "^1.2",
    "drush/example-drush-extension": "1.*",
    "drupal-composer/preserve-paths": "0.1.*",
    "g1a/composer-test-scenarios": "^3.0"
  },
  "config": {
    "vendor-dir": "vendor"
  },
  "extra": {
    "scenarios": {
      "core-drupal": {
        "require": {
            "drupal/drupal": "7.67"
        }
      },
      "pantheon-drops": {
          "require": {
              "pantheon-systems/drops-7-composer": "7.67"
          }
      }
    },
    "installer-paths": {
      "web/": ["type:drupal-core"],
      "web/sites/all/modules/contrib/{$name}/": ["type:drupal-module"],
      "web/sites/all/themes/contrib/{$name}/": ["type:drupal-theme"],
      "web/sites/all/libraries/{$name}/": ["type:drupal-library"],
      "web/sites/all/drush/{$name}/": ["type:drupal-drush"],
      "web/profiles/{$name}/": ["type:drupal-profile"]
    },
    "preserve-paths": [
      "web/sites/all/modules/contrib",
      "web/sites/all/themes/contrib",
      "web/sites/all/libraries",
      "web/sites/all/drush",
      "web/sites/default/settings.php",
      "web/sites/default/files"
    ]
  }
}
```

Unit test added to the PR only verifies the composer.json output at the moment. If a functional unit test is required, let me know.
