### PR TITLE
Composer allow to autoload classes for the same prefix from multiple directories

### DIFF
--- a/src/Handler.php
+++ b/src/Handler.php
@@ -444,16 +444,24 @@ class Handler
     /**
      * Alter one path
      *
-     * @param string $path
+     * @param string|string[] $path
      *   A path, e.g. './web' or 'web'
      *
-     * @return string
+     * @return string|string[]
      *   Path adjusted to compensate for composer.json moving to
      *   .scenarios-lock/scenario/composer.json
      */
     protected function fixPath($path)
     {
-        return '../../' . preg_replace('#^\./#', '', $path);
+        $normalizePath = static function ($path) {
+            return '../../' . preg_replace('#^\./#', '', $path);
+        };
+
+        if (is_array($path)) {
+            return array_map($normalizePath, $path);
+        }
+
+        return $normalizePath($path);
     }
 
     protected function writeComposerData($scenarioData, $scenarioDir)

--- a/tests/fixtures/projects/simple-project/composer.json
+++ b/tests/fixtures/projects/simple-project/composer.json
@@ -19,6 +19,11 @@
             "ComposerTestScenarios\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "ComposerTestScenarios\\": ["src/", "lib/"]
+        }
+    },
     "extra": {
         "scenarios": {
             "semver30": {


### PR DESCRIPTION
Hello,

The Composer schema (https://getcomposer.org/doc/04-schema.md#psr-4) allows us to define array of directories, if we need to search for a same prefix in multiple directories.

At the moment, if we do this we get a error in `Handler.php`: `Array to string conversion`
This PR fixes it.
