### PR TITLE
Cast the return type of the execute command

### DIFF
--- a/src/Commands/ScenarioCommand.php
+++ b/src/Commands/ScenarioCommand.php
@@ -35,6 +35,8 @@ class ScenarioCommand extends BaseCommand
 
     /**
      * {@inheritdoc}
+     *
+     * Note: Symfony commands should always return an integer exit code.
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -45,7 +47,7 @@ class ScenarioCommand extends BaseCommand
         $status = $handler->installScenario($scenario_name, $dependencies, $dir);
 
         if ($status != 0) {
-            return $status;
+            return (int) $status;
         }
 
         // If called from a CI context, print out some extra information about
@@ -54,6 +56,6 @@ class ScenarioCommand extends BaseCommand
             passthru("composer -n --working-dir=$dir info");
         }
 
-        return $status;
+        return (int) $status;
     }
 }

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -162,8 +162,24 @@ class Handler
         return "$dir/vendor/composer/installed.json";
     }
 
+    /**
+     * Install a scenario.
+     *
+     * @param string $scenario
+     *   The scenario to install.
+     * @param string $dependencies
+     *   The dependencies to install.
+     * @param string $dir
+     *   The directory to install the scenario in.
+     *
+     * @return int
+     *   The status code of the install.
+     *
+     * Note: This function should always return an integer, or face the wrath of synfony/process.
+     */
     public function installScenario($scenario, $dependencies, $dir)
     {
+        $status = 0;
         $scenarioDir = static::scenarioLockDir($dir, $scenario);
         if (!is_dir($scenarioDir)) {
             throw new \Exception("The scenario '$scenario' does not exist.");
@@ -174,7 +190,7 @@ class Handler
         passthru("composer -n --working-dir=$scenarioDir validate --no-check-all --ansi", $status);
         // print("composer -n --working-dir=$scenarioDir $scenarioCommand $extraOptions --prefer-dist --no-scripts\n");
         if ($status != 0) {
-            return $status;
+            return (int) $status;
         }
 
         if ($scenarioCommand == 'update') {
@@ -182,7 +198,7 @@ class Handler
         }
 
         passthru("composer -n --working-dir=$scenarioDir install $extraOptions --prefer-dist", $status);
-        return $status;
+        return (int) $status;
     }
 
     protected function determineDependenciesCommand($dependencies)


### PR DESCRIPTION
Symfony will often throw an error if a command returns a null value. This commit casts the value as an integer no matter what.